### PR TITLE
increase autoscaler pod memory to prevent pods from repeated restarts due to OOMKilled

### DIFF
--- a/scripts/cluster_autoscaler.yaml
+++ b/scripts/cluster_autoscaler.yaml
@@ -142,11 +142,11 @@ spec:
           name: cluster-autoscaler
           resources:
             limits:
-              cpu: 100m
-              memory: 300Mi
+              cpu: 200m
+              memory: 1500Mi
             requests:
-              cpu: 100m
-              memory: 300Mi
+              cpu: 200m
+              memory: 1200Mi
           command:
             - ./cluster-autoscaler
             - --v=4


### PR DESCRIPTION
Increase autoscaler pod memory to prevent pods from being killed and restarted due to OOM.